### PR TITLE
Add accelerate to dependencies.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ description = "Unix language driver for software 2.0"
 dependencies = [
     "llama-cpp-python",
     "transformers",
+    "accelerate",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Calling `gpts.OrcaMini3b()` fails without accelerate installed due to the `device_map='auto'` argument.