### PR TITLE
Speed up import time by lazily importing transformers library.

### DIFF
--- a/src/gpts/models.py
+++ b/src/gpts/models.py
@@ -115,8 +115,6 @@ class OpenOrca(Model):
     url_base = "mistral-7b-openorca.Q5_K_M.gguf"
 
 ### In Progress
-from transformers import AutoModelForCausalLM, AutoTokenizer
-
 
 class Transformers:
     url_root = 'https://huggingface.co'
@@ -128,6 +126,7 @@ class Transformers:
 
         os.makedirs(self.path(), exist_ok=True)
         # TODO: set context_length
+        from transformers import AutoModelForCausalLM, AutoTokenizer
         self.tokenizer = AutoTokenizer.from_pretrained(self.url_base, cache_dir=self.path())
         self.model = AutoModelForCausalLM.from_pretrained(self.url_base, cache_dir=self.path(), torch_dtype="auto", device_map="auto") 
 


### PR DESCRIPTION
Tools built on top of the gpts library (e.g., grep2) have an interest in the library's import time.

Moving slow imports of libraries that aren't always needed can help a lot here.

Import time before this PR.
![before](https://github.com/rskottap/gpts/assets/28633680/518fce6d-f24b-43d1-a626-4fb7b901b045)

Import time after this PR.
![after](https://github.com/rskottap/gpts/assets/28633680/568cf5ea-c105-4752-9815-da5054c305a0)

A roughly ~17x speedup.