### PR TITLE
Don't mistake partial downloads for successful ones.

### DIFF
--- a/src/gpts/models.py
+++ b/src/gpts/models.py
@@ -69,7 +69,9 @@ class Model:
 
             # use wget instead of requests to make buffering
             # easier and give us a progress bar, this file is big.
-            os.system(f"wget -O {temp_path!r} {url!r}")
+            status = os.system(f"wget -O {temp_path!r} {url!r}")
+            if status != 0:
+                raise RuntimeError(f"Download interrupted. Keeping partial download at {temp_path!r}")
 
             os.rename(temp_path, cache_path)
             print(f"Model file {cache_path!r} downloaded.", file=sys.stderr)


### PR DESCRIPTION
Python doesn't raise an exception when shell commands fail, so raise an exception on nonzero exit status to prevent incomplete model.gguf.tmp files from being renamed to model.gguf in the case where the user
ctrl+c's out of a download. Without this, the library mistakenly believes interrupted downloads completed successfully.