### PR TITLE
Remove trailing whitespace from LLM outputs.

### DIFF
--- a/src/gpts/models.py
+++ b/src/gpts/models.py
@@ -89,7 +89,7 @@ class Model:
         if self.verbose:
             return output
         else:
-            return re.sub(r"[\s\S]*?\[/INST\]", "", output["choices"][0]["text"])
+            return re.sub(r"[\s\S]*?\[/INST\]\s*", "", output["choices"][0]["text"])
 
 
 class Mistral(Model):


### PR DESCRIPTION
When running `model("Who is Taylor Swift?")`:

Before:
`' Taylor Swift is a well-known...'`

After:
`'Taylor Swift is a well-known...'`